### PR TITLE
Update 3-aws_infrastructure.md

### DIFF
--- a/instructions/3-aws_infrastructure.md
+++ b/instructions/3-aws_infrastructure.md
@@ -85,7 +85,7 @@ How to create it:
 1. Change into `terraform` directory
 
     ```bash
-    cd ~\Spotify-API-Pipeline\terraform
+    cd terraform
     ```
 
 1. Fill in the `default` parameters `variables.tf` file. 


### PR DESCRIPTION
remove the  ~\Spotify-API-Pipeline\ from the cd command since this assumes the user clones the repo to their home directory. The initial instructions say to cd to the repo, so switching directly to the relative path should be okay